### PR TITLE
Add post message example

### DIFF
--- a/src/views/Result.svelte
+++ b/src/views/Result.svelte
@@ -27,6 +27,7 @@
         <Hero size="sm">
             <div class="module">
                 <iframe
+                    name="visualisationFrame"
                     bind:this={iframe}
                     src={module?.value}
                     title="Module window"
@@ -45,7 +46,10 @@
 
     import { moduleDataKey } from '@/config';
 
-    const steps = [{ label: 'Optimade JSON' }, { label: 'Optimade client module' }];
+    const steps = [
+        { label: 'Optimade JSON' },
+        { label: 'Optimade client module' },
+    ];
 </script>
 
 <script lang="ts">
@@ -57,7 +61,20 @@
     let iframe: HTMLIFrameElement | null;
 
     $: if (iframe) {
+        const message = data || code;
         iframe.contentWindow[moduleDataKey] = data || code;
+        iframe.onload = function () {
+            // We wait untill we get a link with a visualisation file
+            const timer = setInterval(() => {
+                const visualisationFrame = window.frames.visualisationFrame;
+
+                // If we get a frame we send a custom message and clear interval
+                if (visualisationFrame) {
+                    visualisationFrame.postMessage('message', '*');
+                    clearInterval(timer);
+                }
+            }, 100);
+        };
     }
 </script>
 


### PR DESCRIPTION
An example of html web page that get a post message and show it in alert.
https://github.com/hodovani/iframe-integration-example/blob/main/index.html

To run this example please:
- Clone this repo https://github.com/hodovani/iframe-integration-example.
- Run python3 -m http.server in the same folder.
- Run optimade.science locally.
- Visit http://localhost:5000/?filter=nelements%3D2&providers=threedd#threedd-144.
- Enter an URL localhost:8000 in the URL field.
- You should get an alert with a message "message".


https://user-images.githubusercontent.com/12833067/106393157-2a73b080-63fe-11eb-8fe3-296600e5afdc.mov

